### PR TITLE
Add TCP connection with fallback to File

### DIFF
--- a/lib/logstash-logger/device.rb
+++ b/lib/logstash-logger/device.rb
@@ -20,6 +20,7 @@ module LogStashLogger
     autoload :Stderr, 'logstash-logger/device/stderr'
     autoload :Balancer, 'logstash-logger/device/balancer'
     autoload :MultiDelegator, 'logstash-logger/device/multi_delegator'
+    autoload :FallbackTCP, 'logstash-logger/device/fallback_tcp'
 
     def self.new(opts)
       opts = opts.dup
@@ -49,6 +50,7 @@ module LogStashLogger
       case type.to_sym
         when :udp then UDP
         when :tcp then TCP
+        when :fallback_tcp then FallbackTCP
         when :unix then Unix
         when :file then File
         when :redis then Redis

--- a/lib/logstash-logger/device/fallback_tcp.rb
+++ b/lib/logstash-logger/device/fallback_tcp.rb
@@ -1,0 +1,67 @@
+require 'openssl'
+require 'logstash-logger/fallback_delivery'
+
+module LogStashLogger
+  module Device
+    class FallbackTCP < TCP
+      attr_accessor :fallback_path, :timeout
+
+      def initialize(opts)
+        super
+        @timeout = opts.fetch(:timeout, 1)
+        @fallback_path = opts.fetch(:fallback_path, 'log/logstash.development.fallback.log')
+      end
+
+      def write_batch(messages, group = nil)
+        reconnect if fallback_delivery?
+        deliver_logs_from_fallback if fallback_file_not_empty? && tcp_delivery?
+
+        io.puts "[#{messages.join(',')}]"
+      rescue Errno::ETIMEDOUT, Errno::ECONNREFUSED, IOError, Errno::EPIPE => e
+        reconnect
+        retry
+      end
+
+      def tcp_io
+        socket = ::Socket.tcp(@host, @port, connect_timeout: timeout)
+        socket.sync = sync unless sync.nil?
+        socket
+      rescue Errno::ETIMEDOUT, Errno::ECONNREFUSED, IOError, Errno::EPIPE => e
+        log_error(e)
+        @io = nil
+        file_io
+      end
+
+      def file_io
+        @file_io = nil if !@file_io.nil? && @file_io.closed?
+        @file_io ||= File.new(path: fallback_path).io
+      end
+
+      def fallback_delivery?
+        !@io.nil? && @io.is_a?(::File)
+      end
+
+      def tcp_delivery?
+        !fallback_delivery?
+      end
+
+      def fallback_file_not_empty?
+        ::File.size?(fallback_path).to_i > 0
+      end
+
+      def deliver_logs_from_fallback
+        file_io.close unless file_io.nil?
+
+        return unless defined?(::Delayed::Job)
+        return if ::Delayed::Job.where('handler LIKE ?', "%ruby/object:LogStashLogger::FallbackDelivery%").exists?
+
+        job_id = ::Delayed::Job.enqueue(background_delivery_job).id
+        error_logger.debug("job id: #{job_id}")
+      end
+
+      def background_delivery_job
+        LogStashLogger::FallbackDelivery.new(host, port, fallback_path)
+      end
+    end
+  end
+end

--- a/lib/logstash-logger/fallback_delivery.rb
+++ b/lib/logstash-logger/fallback_delivery.rb
@@ -1,0 +1,26 @@
+module LogStashLogger
+  class FallbackDelivery
+    attr_accessor :host, :port, :fallback_path, :logger
+
+    def initialize(host, port, fallback_path)
+      @host = host
+      @port = port
+      @fallback_path = fallback_path
+    end
+
+    def perform
+      if ::File.size?(fallback_path).to_i > 0
+        sock = Socket.tcp(host, port)
+        ::File.readlines(fallback_path).each { |message| sock.puts message }
+        ::File.delete(fallback_path)
+      end
+    rescue Errno::ETIMEDOUT, Errno::ECONNREFUSED, IOError, Errno::EPIPE => e
+      Rails.logger.error(e)
+    ensure
+      if sock && !sock.closed?
+        sock.flush
+        sock.close
+      end
+    end
+  end
+end

--- a/spec/device/fallback_tcp_spec.rb
+++ b/spec/device/fallback_tcp_spec.rb
@@ -1,0 +1,87 @@
+require 'logstash-logger'
+
+describe LogStashLogger::Device::FallbackTCP do
+  include_context 'device'
+
+  let(:fallback_path) { `pwd` + '/logstash.fallback.log' }
+  let(:fallback_tcp_device) do
+    LogStashLogger::Device.new(
+      type: :fallback_tcp,
+      port: port,
+      fallback_path: fallback_path,
+      error_logger: Logger.new(IO::NULL),
+      sync: true)
+  end
+
+  context "when server unavailable" do
+    before do
+      allow(fallback_tcp_device.error_logger).to receive(:error)
+      allow(fallback_tcp_device.error_logger).to receive(:warn)
+      allow(::Socket).to receive(:tcp).with(HOST, port, connect_timeout: 1).and_raise(Errno::ETIMEDOUT)
+    end
+
+    it "returns file io as fallback" do
+      expect(fallback_tcp_device.io).to be_a(::File)
+    end
+
+    it "has marked as fallback delivery" do
+      fallback_tcp_device.connect
+      expect(fallback_tcp_device).to be_fallback_delivery
+    end
+
+    it 'has io with :fallback_path option' do
+      expect(fallback_tcp_device.io.path).to include('/logstash.fallback.log')
+    end
+  end
+
+  describe '#write_batch' do
+    let(:tcp_socket) { instance_double(IO) }
+
+    before do
+      allow(tcp_socket).to receive(:sync=)
+      allow(fallback_tcp_device).to receive(:deliver_logs_from_fallback)
+      allow(fallback_tcp_device).to receive(:fallback_file_not_empty?).and_return(true)
+    end
+
+    context 'when server appears online' do
+      before do
+        allow(::Socket).to receive(:tcp).with(HOST, port, connect_timeout: 1).and_raise(Errno::ETIMEDOUT)
+        allow(tcp_socket).to receive(:puts)
+      end
+
+      it 'switches from file to tcp' do
+        expect(fallback_tcp_device.io).to be_a(File)
+        fallback_tcp_device.write_batch(['message'])
+        allow(::Socket).to receive(:tcp).with(HOST, port, connect_timeout: 1).and_return(tcp_socket)
+        fallback_tcp_device.write_batch(['message'])
+        expect(fallback_tcp_device.io).to eq(tcp_socket)
+      end
+
+      it 'delivers data from log file' do
+        allow(::Socket).to receive(:tcp).with(HOST, port, connect_timeout: 1).and_return(tcp_socket)
+        fallback_tcp_device.write_batch(['message'])
+        expect(fallback_tcp_device).to have_received(:deliver_logs_from_fallback)
+      end
+    end
+
+    context 'when server goes offline' do
+      before do
+        allow(::Socket).to receive(:tcp).with(HOST, port, connect_timeout: 1).and_return(tcp_socket)
+        allow(tcp_socket).to receive(:puts)
+      end
+
+      it 'switches from file to tcp' do
+        fallback_tcp_device.write_batch(['message'])
+        expect(fallback_tcp_device.io).to eq(tcp_socket)
+        allow(tcp_socket).to receive(:puts).and_raise(Errno::EPIPE)
+        allow(::Socket).to receive(:tcp).with(HOST, port, connect_timeout: 1).and_raise(Errno::ETIMEDOUT)
+        allow(tcp_socket).to receive(:closed?).and_return(true)
+        allow(tcp_socket).to receive(:close)
+        fallback_tcp_device.with_connection do
+          fallback_tcp_device.write_batch(['message'])
+        end
+        expect(fallback_tcp_device.io).to be_a(File)
+      end
+    end
+  end
+end

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -11,8 +11,6 @@ module Test
   end
 end
 
-Test::Application.initialize!
-
 describe LogStashLogger do
   include_context 'device'
 


### PR DESCRIPTION
 - create a file to log the events if Logstash unavailable;
 - recover connection if Logstash appears online;
 - deliver events from fallback File to Logstash when it appears online;